### PR TITLE
build: update to mirror.gcr.io/library/golang:1.25

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -2,7 +2,7 @@
 # Builder image
 # See https://hub.docker.com/_/golang/
 ################################################################################################
-FROM --platform=$BUILDPLATFORM golang:1.25 AS builder
+FROM --platform=$BUILDPLATFORM mirror.gcr.io/library/golang:1.25 AS builder
 
 WORKDIR /usr/src/app
 

--- a/test/e2e/argocd-server-mock/Containerfile
+++ b/test/e2e/argocd-server-mock/Containerfile
@@ -2,7 +2,7 @@
 # Builder image
 # See https://hub.docker.com/_/golang/
 ################################################################################################
-FROM golang:1.25 as argocd-mock-server-builder
+FROM mirror.gcr.io/library/golang:1.25 as argocd-mock-server-builder
 
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
in order to avoid hitting the Docker Hub quota limits when pulling the golang image on CI

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker base image configuration for build consistency across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->