### PR TITLE
refactor: rename tools with kebab-casing

### DIFF
--- a/internal/argocd/unhealthy_application_resources.go
+++ b/internal/argocd/unhealthy_application_resources.go
@@ -88,7 +88,7 @@ func init() {
 		log.Fatalf("failed to create UnhealthyApplicationResourcesOutputSchema: %v", err.Error())
 	}
 	UnhealthyApplicationResourcesTool = &mcp.Tool{
-		Name:         "argocd_list_unhealthy_application_resources",
+		Name:         "argocd-list-unhealthy-application-resources",
 		Description:  "list unhealthy resources of a given Argo CD Application",
 		InputSchema:  UnhealthyApplicationResourcesInputSchema,
 		OutputSchema: UnhealthyApplicationResourcesOutputSchema,
@@ -125,7 +125,7 @@ func listUnhealthyApplicationResources(ctx context.Context, logger *slog.Logger,
 		if err != nil {
 			logger.Error("failed to convert unhealthy resources to text", "error", err.Error())
 		}
-		logger.DebugContext(ctx, "returned 'tools/call' response", "tool", "argocd_list_unhealthy_application_resources", "app", name, "result", string(unhealthyResourcesStr))
+		logger.DebugContext(ctx, "returned 'tools/call' response", "tool", "argocd-list-unhealthy-application-resources", "app", name, "result", string(unhealthyResourcesStr))
 	}
 	return UnhealthyResources{
 		Resources: unhealthyResources,

--- a/internal/argocd/unhealthy_applications.go
+++ b/internal/argocd/unhealthy_applications.go
@@ -36,7 +36,7 @@ func init() {
 	}
 	log.Println("UnhealthyApplicationsOutputSchema initialized")
 	UnhealthyApplicationsTool = &mcp.Tool{
-		Name:         "argocd_list_unhealthy_applications",
+		Name:         "argocd-list-unhealthy-applications",
 		Description:  "list the unhealthy ('degraded' and 'progressing') Applications in Argo CD",
 		InputSchema:  UnhealthyApplicationsInputSchema,
 		OutputSchema: UnhealthyApplicationsOutputSchema,
@@ -99,7 +99,7 @@ func listUnhealthyApplications(ctx context.Context, logger *slog.Logger, cl *Cli
 		if err != nil {
 			logger.Error("failed to convert unhealthy resources to text", "error", err.Error())
 		}
-		logger.DebugContext(ctx, "returned 'tools/call' response", "tool", "argocd_list_unhealthy_applications", "result", string(unhealthyAppsStr))
+		logger.DebugContext(ctx, "returned 'tools/call' response", "tool", "argocd-list-unhealthy-applications", "result", string(unhealthyAppsStr))
 	}
 	return unhealthyApps, nil
 }

--- a/taskfile.yaml
+++ b/taskfile.yaml
@@ -12,6 +12,11 @@ tasks:
     cmds:
       - curl -sSfL https://golangci-lint.run/install.sh | sh -s -- -b $GOPATH/bin
       - $GOPATH/bin/golangci-lint run -v -c .golangci.yml ./...
+  
+  # Vulnerability Scanning
+  vuln-scan:
+    cmds:
+      - govulncheckx --path=. --config .govulncheck.yaml
 
   # Vulnerability Scanning
   vuln-scan:

--- a/test/e2e/server_test.go
+++ b/test/e2e/server_test.go
@@ -23,7 +23,7 @@ import (
 
 // TestServer verifies basic MCP functionality with http transport.
 // Both transports run in stateful mode (ListChanged enabled) and test:
-// - Tool calls (argocd_list_unhealthy_applications, argocd_list_unhealthy_application_resources)
+// - Tool calls (argocd-list-unhealthy-applications, argocd-list-unhealthy-application-resources)
 // - Error handling (argocd-error, unreachable scenarios)
 // - Metrics collection (for http transport)
 // - Session reuse across multiple tool calls
@@ -37,20 +37,20 @@ func TestStatefulServer(t *testing.T) {
 		require.NoError(t, err)
 		defer session.Close()
 
-		t.Run("call/argocd_list_unhealthy_applications/ok", func(t *testing.T) {
+		t.Run("call/argocd-list-unhealthy-applications/ok", func(t *testing.T) {
 			// get the metrics before the call
 			var mcpCallsTotalMetricBefore int64
 			var mcpCallsDurationSecondsInfBucketBefore int64
 			mcpCallsTotalMetricBefore, mcpCallsDurationSecondsInfBucketBefore = getMetrics(t, "http://localhost:50081", map[string]string{
 				"server":  "argocd-mcp-server",
 				"method":  "tools/call",
-				"name":    "argocd_list_unhealthy_applications",
+				"name":    "argocd-list-unhealthy-applications",
 				"success": "true",
 			})
 
 			// when
 			result, err := session.CallTool(context.Background(), &mcp.CallToolParams{
-				Name: "argocd_list_unhealthy_applications",
+				Name: "argocd-list-unhealthy-applications",
 			})
 
 			// then
@@ -78,26 +78,26 @@ func TestStatefulServer(t *testing.T) {
 			mcpCallsTotalMetricAfter, mcpCallsDurationSecondsInfBucketAfter := getMetrics(t, "http://localhost:50081", map[string]string{
 				"server":  "argocd-mcp-server",
 				"method":  "tools/call",
-				"name":    "argocd_list_unhealthy_applications",
+				"name":    "argocd-list-unhealthy-applications",
 				"success": "true",
 			})
 			assert.Equal(t, mcpCallsTotalMetricBefore+1, mcpCallsTotalMetricAfter)
 			assert.Equal(t, mcpCallsDurationSecondsInfBucketBefore+1, mcpCallsDurationSecondsInfBucketAfter)
 		})
 
-		t.Run("call/argocd_list_unhealthy_application_resources/ok", func(t *testing.T) {
+		t.Run("call/argocd-list-unhealthy-application-resources/ok", func(t *testing.T) {
 			var mcpCallsTotalMetricBefore int64
 			var mcpCallsDurationSecondsInfBucketBefore int64
 			mcpCallsTotalMetricBefore, mcpCallsDurationSecondsInfBucketBefore = getMetrics(t, "http://localhost:50081", map[string]string{
 				"server":  "argocd-mcp-server",
 				"method":  "tools/call",
-				"name":    "argocd_list_unhealthy_application_resources",
+				"name":    "argocd-list-unhealthy-application-resources",
 				"success": "true",
 			})
 
 			// when
 			result, err := session.CallTool(context.Background(), &mcp.CallToolParams{
-				Name: "argocd_list_unhealthy_application_resources",
+				Name: "argocd-list-unhealthy-application-resources",
 				Arguments: map[string]any{
 					"name": "example",
 				},
@@ -157,26 +157,26 @@ func TestStatefulServer(t *testing.T) {
 			mcpCallsTotalMetricAfter, mcpCallsDurationSecondsInfBucketAfter := getMetrics(t, "http://localhost:50081", map[string]string{
 				"server":  "argocd-mcp-server",
 				"method":  "tools/call",
-				"name":    "argocd_list_unhealthy_application_resources",
+				"name":    "argocd-list-unhealthy-application-resources",
 				"success": "true",
 			})
 			assert.Equal(t, mcpCallsTotalMetricBefore+1, mcpCallsTotalMetricAfter)
 			assert.Equal(t, mcpCallsDurationSecondsInfBucketBefore+1, mcpCallsDurationSecondsInfBucketAfter)
 		})
 
-		t.Run("call/argocd_list_unhealthy_application_resources/argocd-error", func(t *testing.T) {
+		t.Run("call/argocd-list-unhealthy-application-resources/argocd-error", func(t *testing.T) {
 			var mcpCallsTotalMetricBefore int64
 			var mcpCallsDurationSecondsInfBucketBefore int64
 			mcpCallsTotalMetricBefore, mcpCallsDurationSecondsInfBucketBefore = getMetrics(t, "http://localhost:50081", map[string]string{
 				"server":  "argocd-mcp-server",
 				"method":  "tools/call",
-				"name":    "argocd_list_unhealthy_application_resources",
+				"name":    "argocd-list-unhealthy-application-resources",
 				"success": "false",
 			})
 
 			// when
 			result, err := session.CallTool(context.Background(), &mcp.CallToolParams{
-				Name: "argocd_list_unhealthy_application_resources",
+				Name: "argocd-list-unhealthy-application-resources",
 				Arguments: map[string]any{
 					"name": "example-error",
 				},
@@ -189,7 +189,7 @@ func TestStatefulServer(t *testing.T) {
 			mcpCallsTotalMetricAfter, mcpCallsDurationSecondsInfBucketAfter := getMetrics(t, "http://localhost:50081", map[string]string{
 				"server":  "argocd-mcp-server",
 				"method":  "tools/call",
-				"name":    "argocd_list_unhealthy_application_resources",
+				"name":    "argocd-list-unhealthy-application-resources",
 				"success": "false",
 			})
 			assert.Equal(t, mcpCallsTotalMetricBefore+1, mcpCallsTotalMetricAfter)
@@ -208,10 +208,10 @@ func TestStatefulServer(t *testing.T) {
 		session, err := newHTTPSession(ctx, "http://localhost:50082/mcp", "e2e-test-client")
 		require.NoError(t, err)
 		defer session.Close()
-		t.Run("call/argocd_list_unhealthy_applications/argocd-unreachable", func(t *testing.T) {
+		t.Run("call/argocd-list-unhealthy-applications/argocd-unreachable", func(t *testing.T) {
 			// when
 			result, err := session.CallTool(context.Background(), &mcp.CallToolParams{
-				Name: "argocd_list_unhealthy_applications",
+				Name: "argocd-list-unhealthy-applications",
 			})
 
 			// then
@@ -250,7 +250,7 @@ func TestStatelessServer(t *testing.T) {
 
 	// Step 4: Verify tools work correctly with content validation
 	result, callErr := session.CallTool(ctx, &mcp.CallToolParams{
-		Name: "argocd_list_unhealthy_applications",
+		Name: "argocd-list-unhealthy-applications",
 	})
 	require.NoError(t, callErr)
 	require.False(t, result.IsError, "tool call should succeed")


### PR DESCRIPTION
Signed-off-by: Xavier Coulon <xcoulon@redhat.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changes**
  * Updated Argo CD MCP tool names to hyphenated formatting for consistent discovery and invocation.
  * Added a vulnerability-scanning `vuln-scan` task to the development workflow.
  * Updated end-to-end validation and monitoring checks to use the revised tool names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->