### PR TITLE
refactor: rename tools with camel_casing

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Argo CD MCP is a Model Context Protocol Server to converse with Argo CD from a U
 ## Features
 
 - Prompts:
-  - `argocd-unhealthy-application-resources`: list the Unhealthy (`Degraded` and `Progressing`) Applications in Argo CD
+  - `argocd_unhealthy_application_resources`: list the Unhealthy (`Degraded` and `Progressing`) Applications in Argo CD
 - Tools:
   - `argocd_list_unhealthy_applications`: list the unhealthy (`Degraded` and `Progressing`) Applications in Argo CD
   - `argocd_list_unhealthy_application_resources`: list unhealthy resources of a given Argo CD Application

--- a/internal/argocd/unhealthy_application_resources.go
+++ b/internal/argocd/unhealthy_application_resources.go
@@ -16,7 +16,7 @@ import (
 )
 
 var UnhealthyResourcesPrompt = &mcp.Prompt{
-	Name:        "argocd-unhealthy-application-resources",
+	Name:        "argocd_unhealthy_application_resources",
 	Description: "The unhealthy resources of the Argo CD Application prompt",
 	Arguments: []*mcp.PromptArgument{
 		{
@@ -88,7 +88,7 @@ func init() {
 		log.Fatalf("failed to create UnhealthyApplicationResourcesOutputSchema: %v", err.Error())
 	}
 	UnhealthyApplicationResourcesTool = &mcp.Tool{
-		Name:         "argocd-list-unhealthy-application-resources",
+		Name:         "argocd_list_unhealthy_application_resources",
 		Description:  "list unhealthy resources of a given Argo CD Application",
 		InputSchema:  UnhealthyApplicationResourcesInputSchema,
 		OutputSchema: UnhealthyApplicationResourcesOutputSchema,
@@ -125,7 +125,7 @@ func listUnhealthyApplicationResources(ctx context.Context, logger *slog.Logger,
 		if err != nil {
 			logger.Error("failed to convert unhealthy resources to text", "error", err.Error())
 		}
-		logger.DebugContext(ctx, "returned 'tools/call' response", "tool", "argocd-list-unhealthy-application-resources", "app", name, "result", string(unhealthyResourcesStr))
+		logger.DebugContext(ctx, "returned 'tools/call' response", "tool", "argocd_list_unhealthy_application_resources", "app", name, "result", string(unhealthyResourcesStr))
 	}
 	return UnhealthyResources{
 		Resources: unhealthyResources,

--- a/internal/argocd/unhealthy_applications.go
+++ b/internal/argocd/unhealthy_applications.go
@@ -36,7 +36,7 @@ func init() {
 	}
 	log.Println("UnhealthyApplicationsOutputSchema initialized")
 	UnhealthyApplicationsTool = &mcp.Tool{
-		Name:         "argocd-list-unhealthy-applications",
+		Name:         "argocd_list_unhealthy_applications",
 		Description:  "list the unhealthy ('degraded' and 'progressing') Applications in Argo CD",
 		InputSchema:  UnhealthyApplicationsInputSchema,
 		OutputSchema: UnhealthyApplicationsOutputSchema,
@@ -99,7 +99,7 @@ func listUnhealthyApplications(ctx context.Context, logger *slog.Logger, cl *Cli
 		if err != nil {
 			logger.Error("failed to convert unhealthy resources to text", "error", err.Error())
 		}
-		logger.DebugContext(ctx, "returned 'tools/call' response", "tool", "argocd-list-unhealthy-applications", "result", string(unhealthyAppsStr))
+		logger.DebugContext(ctx, "returned 'tools/call' response", "tool", "argocd_list_unhealthy_applications", "result", string(unhealthyAppsStr))
 	}
 	return unhealthyApps, nil
 }

--- a/test/e2e/server_test.go
+++ b/test/e2e/server_test.go
@@ -23,7 +23,7 @@ import (
 
 // TestServer verifies basic MCP functionality with http transport.
 // Both transports run in stateful mode (ListChanged enabled) and test:
-// - Tool calls (argocd-list-unhealthy-applications, argocd-list-unhealthy-application-resources)
+// - Tool calls (argocd_list_unhealthy_applications, argocd_list_unhealthy_application_resources)
 // - Error handling (argocd-error, unreachable scenarios)
 // - Metrics collection (for http transport)
 // - Session reuse across multiple tool calls
@@ -37,20 +37,20 @@ func TestStatefulServer(t *testing.T) {
 		require.NoError(t, err)
 		defer session.Close()
 
-		t.Run("call/argocd-list-unhealthy-applications/ok", func(t *testing.T) {
+		t.Run("call/argocd_list_unhealthy_applications/ok", func(t *testing.T) {
 			// get the metrics before the call
 			var mcpCallsTotalMetricBefore int64
 			var mcpCallsDurationSecondsInfBucketBefore int64
 			mcpCallsTotalMetricBefore, mcpCallsDurationSecondsInfBucketBefore = getMetrics(t, "http://localhost:50081", map[string]string{
 				"server":  "argocd-mcp-server",
 				"method":  "tools/call",
-				"name":    "argocd-list-unhealthy-applications",
+				"name":    "argocd_list_unhealthy_applications",
 				"success": "true",
 			})
 
 			// when
 			result, err := session.CallTool(context.Background(), &mcp.CallToolParams{
-				Name: "argocd-list-unhealthy-applications",
+				Name: "argocd_list_unhealthy_applications",
 			})
 
 			// then
@@ -78,26 +78,26 @@ func TestStatefulServer(t *testing.T) {
 			mcpCallsTotalMetricAfter, mcpCallsDurationSecondsInfBucketAfter := getMetrics(t, "http://localhost:50081", map[string]string{
 				"server":  "argocd-mcp-server",
 				"method":  "tools/call",
-				"name":    "argocd-list-unhealthy-applications",
+				"name":    "argocd_list_unhealthy_applications",
 				"success": "true",
 			})
 			assert.Equal(t, mcpCallsTotalMetricBefore+1, mcpCallsTotalMetricAfter)
 			assert.Equal(t, mcpCallsDurationSecondsInfBucketBefore+1, mcpCallsDurationSecondsInfBucketAfter)
 		})
 
-		t.Run("call/argocd-list-unhealthy-application-resources/ok", func(t *testing.T) {
+		t.Run("call/argocd_list_unhealthy_application_resources/ok", func(t *testing.T) {
 			var mcpCallsTotalMetricBefore int64
 			var mcpCallsDurationSecondsInfBucketBefore int64
 			mcpCallsTotalMetricBefore, mcpCallsDurationSecondsInfBucketBefore = getMetrics(t, "http://localhost:50081", map[string]string{
 				"server":  "argocd-mcp-server",
 				"method":  "tools/call",
-				"name":    "argocd-list-unhealthy-application-resources",
+				"name":    "argocd_list_unhealthy_application_resources",
 				"success": "true",
 			})
 
 			// when
 			result, err := session.CallTool(context.Background(), &mcp.CallToolParams{
-				Name: "argocd-list-unhealthy-application-resources",
+				Name: "argocd_list_unhealthy_application_resources",
 				Arguments: map[string]any{
 					"name": "example",
 				},
@@ -157,26 +157,26 @@ func TestStatefulServer(t *testing.T) {
 			mcpCallsTotalMetricAfter, mcpCallsDurationSecondsInfBucketAfter := getMetrics(t, "http://localhost:50081", map[string]string{
 				"server":  "argocd-mcp-server",
 				"method":  "tools/call",
-				"name":    "argocd-list-unhealthy-application-resources",
+				"name":    "argocd_list_unhealthy_application_resources",
 				"success": "true",
 			})
 			assert.Equal(t, mcpCallsTotalMetricBefore+1, mcpCallsTotalMetricAfter)
 			assert.Equal(t, mcpCallsDurationSecondsInfBucketBefore+1, mcpCallsDurationSecondsInfBucketAfter)
 		})
 
-		t.Run("call/argocd-list-unhealthy-application-resources/argocd-error", func(t *testing.T) {
+		t.Run("call/argocd_list_unhealthy_application_resources/argocd-error", func(t *testing.T) {
 			var mcpCallsTotalMetricBefore int64
 			var mcpCallsDurationSecondsInfBucketBefore int64
 			mcpCallsTotalMetricBefore, mcpCallsDurationSecondsInfBucketBefore = getMetrics(t, "http://localhost:50081", map[string]string{
 				"server":  "argocd-mcp-server",
 				"method":  "tools/call",
-				"name":    "argocd-list-unhealthy-application-resources",
+				"name":    "argocd_list_unhealthy_application_resources",
 				"success": "false",
 			})
 
 			// when
 			result, err := session.CallTool(context.Background(), &mcp.CallToolParams{
-				Name: "argocd-list-unhealthy-application-resources",
+				Name: "argocd_list_unhealthy_application_resources",
 				Arguments: map[string]any{
 					"name": "example-error",
 				},
@@ -189,7 +189,7 @@ func TestStatefulServer(t *testing.T) {
 			mcpCallsTotalMetricAfter, mcpCallsDurationSecondsInfBucketAfter := getMetrics(t, "http://localhost:50081", map[string]string{
 				"server":  "argocd-mcp-server",
 				"method":  "tools/call",
-				"name":    "argocd-list-unhealthy-application-resources",
+				"name":    "argocd_list_unhealthy_application_resources",
 				"success": "false",
 			})
 			assert.Equal(t, mcpCallsTotalMetricBefore+1, mcpCallsTotalMetricAfter)
@@ -208,10 +208,10 @@ func TestStatefulServer(t *testing.T) {
 		session, err := newHTTPSession(ctx, "http://localhost:50082/mcp", "e2e-test-client")
 		require.NoError(t, err)
 		defer session.Close()
-		t.Run("call/argocd-list-unhealthy-applications/argocd-unreachable", func(t *testing.T) {
+		t.Run("call/argocd_list_unhealthy_applications/argocd-unreachable", func(t *testing.T) {
 			// when
 			result, err := session.CallTool(context.Background(), &mcp.CallToolParams{
-				Name: "argocd-list-unhealthy-applications",
+				Name: "argocd_list_unhealthy_applications",
 			})
 
 			// then
@@ -250,7 +250,7 @@ func TestStatelessServer(t *testing.T) {
 
 	// Step 4: Verify tools work correctly with content validation
 	result, callErr := session.CallTool(ctx, &mcp.CallToolParams{
-		Name: "argocd-list-unhealthy-applications",
+		Name: "argocd_list_unhealthy_applications",
 	})
 	require.NoError(t, callErr)
 	require.False(t, result.IsError, "tool call should succeed")


### PR DESCRIPTION
this is the most common naming convention in the MCP server community

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the documented prompt name for listing unhealthy application resources.

* **Changes**
  * Standardized unhealthy application and resource tool names to use underscores instead of hyphens.
  * Updated related logging and metrics labels to reflect the new names.

* **Tests**
  * Updated server tests to use and validate the standardized tool names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->